### PR TITLE
nix: add passthru.pkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,4 +6,8 @@ let
     ];
   };
 in
-pkgs.diff-treesPackages.diff-trees
+pkgs.diff-treesPackages.diff-trees.overrideAttrs (prev: {
+  passthru = (prev.passthru or { }) // {
+    inherit pkgs;
+  };
+})


### PR DESCRIPTION
This lets you do `nix build -f . cargo` or whatnot.