### PR TITLE
fix the nix shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.direnv/

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
 let
-  diff-trees = import ./default.nix;
+  diff-trees = import ./default.nix { };
 in
 diff-trees.shell


### PR DESCRIPTION
Previously:

```
» nix-shell
error:
       … while selecting 'shell'
         at /Users/harry/oss/diff-trees/shell.nix:4:12:
            3| in
            4| diff-trees.shell
             |            ^
            5|

       error: expected a set but found a function: «lambda @ /Users/harry/oss/diff-trees/default.nix:1:1»
```