### PR TITLE
Add Diff::retain_interesting()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fs-err"
@@ -97,24 +97,23 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
 ]
 
 [[package]]
 name = "iddqd"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fdf1948b8b266e6159b301497280248f0399d2769611a7b75b4621812327b5"
+checksum = "b1fb967ac6b9edb2b5bd91496fc95fdf5eee0772aa31aca370766975f7e57962"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
  "hashbrown",
- "rustc-hash",
 ]
 
 [[package]]
@@ -173,12 +172,6 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ categories = ["filesystem"]
 
 [dependencies]
 blake3 = { version = "1.8.2", features = ["mmap"] }
-iddqd = { version = "0.3.11", default-features = false, features = ["std"] }
+iddqd = { version = "0.4.1", default-features = false, features = ["std"] }
 owo-colors = "4.2.2"
 tracing = "0.1.41"
 walkdir = "2.5.0"

--- a/nix/pkgs/diff-trees.nix
+++ b/nix/pkgs/diff-trees.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage {
 
   inherit src;
 
-  cargoHash = "sha256-sRgkUHY1wWH98gZIsXa0eK5k8U8eQkktXxlpz54N9RU=";
+  cargoHash = "sha256-V/dfFJakFuvRUBnjGiQ0AiFd5D5+X5GDSGzarq6qCOc=";
 
   meta = {
     description = "directory tree diffs";

--- a/src/diff_entry.rs
+++ b/src/diff_entry.rs
@@ -83,23 +83,25 @@ impl<'a> DiffEntry<'a> {
             Style::new()
         };
 
-        match self.tag {
-            DiffTag::Equal => {}
-            DiffTag::Delete => {
-                writeln!(f, "{}", self.styled(style))?;
-            }
-            DiffTag::Replace => {
-                // Directory entries are not very useful for me. This should probably also be
-                // customizable.
-                if !self.is_dir() {
-                    writeln!(f, "{}", self.styled(style))?;
-                }
-            }
-            DiffTag::Insert => {
-                writeln!(f, "{}", self.styled(style))?;
-            }
+        if self.is_interesting() {
+            writeln!(f, "{}", self.styled(style))?;
         }
         Ok(())
+    }
+
+    /// Check if a DiffEntry is considered "interesting", which here is equivalent to "do we want it
+    /// to show up in a diff". Equal entries are uninteresting, as are directory Replace entries
+    /// (because directories have no content on their own, so the only thing that can differ is
+    /// metadata, which we usually don't care about anyway).
+    pub(crate) fn is_interesting(&self) -> bool {
+        match self.tag {
+            DiffTag::Equal => false,
+            DiffTag::Delete => true,
+            // Directory entries are not very useful for me. This should probably also be
+            // customizable.
+            DiffTag::Replace => !self.is_dir(),
+            DiffTag::Insert => true,
+        }
     }
 
     #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,13 @@ impl<'a> Diff<'a> {
     pub fn display(&'a self, opts: DisplayDiffOpts) -> impl Display + 'a {
         DisplayDiff { diff: self, opts }
     }
+
+    /// Remove all "uninteresting" values from this diff (i.e. those that would not show up in a
+    /// diff). You can check whether a diff is semantically empty (i.e. contains no interesting
+    /// values) by calling this method, followed by [`is_empty`].
+    pub fn retain_interesting(&mut self) -> () {
+        self.entries.retain(|e| e.is_interesting())
+    }
 }
 
 /// Display the diff with default options (no ANSI colors).
@@ -356,6 +363,39 @@ mod tests {
             ]
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_retain_interesting() -> Result<()> {
+        let mut old = TempTree::new().unwrap();
+        let mut new = TempTree::new().unwrap();
+        for tree in [&mut old, &mut new] {
+            tree.dir("a")
+                .unwrap()
+                .file("a/1", "1")
+                .unwrap()
+                .file("a/2", "2")
+                .unwrap()
+                .dir("b")
+                .unwrap()
+                .file("b/1", "1")
+                .unwrap()
+                .file("b/2", "2")
+                .unwrap()
+                .dir("c")
+                .unwrap()
+                .file("c/1", "1")
+                .unwrap()
+                .file("c/2", "2")
+                .unwrap();
+        }
+
+        let mut diff = Diff::new(old.as_ref(), new.as_ref())?;
+
+        assert!(!diff.entries.is_empty());
+        diff.retain_interesting();
+        assert!(diff.entries.is_empty());
         Ok(())
     }
 }


### PR DESCRIPTION
Bumped `iddqd` to the latest version to get access to `retain`, which was added in 0.3.15.

See: https://github.com/9999years/npingler/issues/68#issuecomment-4481101391